### PR TITLE
Update comment typo and max JSS

### DIFF
--- a/lib/d3/database.rb
+++ b/lib/d3/database.rb
@@ -41,8 +41,8 @@ module D3
     # the minimum JSS schema version allower
     MIN_SCHEMA_VERSION = "9.4"
 
-    # the minimum JSS schema version allower
-    MAX_SCHEMA_VERSION = "9.82"
+    # the maximum JSS schema version allower
+    MAX_SCHEMA_VERSION = "9.92"
 
     ### these Proc objects allow us to encapsulate and pass around various
     ### blocks of code more easily for converting data between their mysql


### PR DESCRIPTION
Comment for MAX_SCHEMA was stating "the **minimum** JSS schema version allowed"
Changed MAX_SCHEMA_VERSION from 9.82 to 9.92
